### PR TITLE
Quietens logs by adding schema for new fields

### DIFF
--- a/robots/payload.go
+++ b/robots/payload.go
@@ -28,6 +28,8 @@ type Payload struct {
 	TriggerWord string  `schema:"trigger_word,omitempty"`
 	ServiceID   string  `schema:"service_id,omitempty"`
 	ResponseUrl string  `schema:"response_url,omitempty"`
+	BotID       string  `schema:"bot_id,omitempty"`
+	BotName     string  `schema:"bot_name,omitempty"`
 	Robot       string
 }
 


### PR DESCRIPTION
Previous log messages looked like:
2016/02/18 09:35:09 Couldn't parse post request: schema: invalid path "bot_id" (and 1 other error)