### PR TITLE
Fix trim of TriggerWord

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,7 @@ func hookHandler(robotMap map[string][]robots.Robot) http.HandlerFunc {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		com := strings.TrimPrefix(command.Text, command.TriggerWord+" ")
+		com := strings.TrimPrefix(command.Text, command.TriggerWord)
 		c := strings.Split(com, " ")
 		command.Robot = c[0]
 		command.Text = strings.Join(c[1:], " ")


### PR DESCRIPTION
The extra `+" "` was causing the trigger word to not be parsed properly. According to Slack docs trigger word should not include any white space between the trigger and the command.